### PR TITLE
Promote https in service urls

### DIFF
--- a/views/services.ejs
+++ b/views/services.ejs
@@ -38,7 +38,7 @@
 
       <h3>CRAN versions</h3>
       <p><code>
-	  http://www.r-pkg.org/badges/version/{package}
+	  https://www.r-pkg.org/badges/version/{package}
       </code></p>
       <p>
 	<img src="/badges/version/Rcpp">
@@ -52,10 +52,10 @@
 
       <h3>CRAN release dates</h3>
       <p>
-	<code>http://www.r-pkg.org/badges/version-ago/{package}</code><br/>
-	<code>http://www.r-pkg.org/badges/version-last-release/{package}</code><br/>
-	<code>http://www.r-pkg.org/badges/ago/{package}</code><br/>
-	<code>http://www.r-pkg.org/badges/last-release/{package}</code>
+	<code>https://www.r-pkg.org/badges/version-ago/{package}</code><br/>
+	<code>https://www.r-pkg.org/badges/version-last-release/{package}</code><br/>
+	<code>https://www.r-pkg.org/badges/ago/{package}</code><br/>
+	<code>https://www.r-pkg.org/badges/last-release/{package}</code>
       </code></p>
       <p>
 	<img src="/badges/version-ago/Rcpp">
@@ -69,13 +69,13 @@
 
       <h3>CRAN downloads</h3>
       <p><code>
-	  http://cranlogs.r-pkg.org/badges/{summary}/{package}
+	  https://cranlogs.r-pkg.org/badges/{summary}/{package}
       </code></p>
       <p>
-	<img src="http://cranlogs.r-pkg.org/badges/grand-total/Rcpp">
-	<img src="http://cranlogs.r-pkg.org/badges/last-month/Rcpp">
-	<img src="http://cranlogs.r-pkg.org/badges/last-week/Rcpp">
-	<img src="http://cranlogs.r-pkg.org/badges/last-day/Rcpp">
+	<img src="https://cranlogs.r-pkg.org/badges/grand-total/Rcpp">
+	<img src="https://cranlogs.r-pkg.org/badges/last-month/Rcpp">
+	<img src="https://cranlogs.r-pkg.org/badges/last-week/Rcpp">
+	<img src="https://cranlogs.r-pkg.org/badges/last-day/Rcpp">
       </p>
       <p>
 	Shows number of downloads for a given package, see
@@ -106,8 +106,8 @@
       <h3 id="crandb">Package database</h3>
       <p>
 	Database of all CRAN R packages. It is a CouchDB database,
-	hosted at <a href="http://crandb.r-pkg.org/">
-	  http://crandb.r-pkg.org/</a>.	Its API is discussed at the project
+	hosted at <a href="https://crandb.r-pkg.org/">
+	  https://crandb.r-pkg.org/</a>.	Its API is discussed at the project
 	page: <a href="https://github.com/metacran/crandb">
 	  https://github.com/metacran/crandb</a>.
       </p>
@@ -124,9 +124,9 @@
       <h3 id="cranlogs">Package downloads</h3>
       <p>
 	Download summaries from the RStudio CRAN mirror,
-	taken from <a href="http://cran-logs.rstudio.com/">
+	taken from <a href="https://cran-logs.rstudio.com/">
 	  http://cran-logs.rstudio.com/</a>.
-	It is hosted <a href="http://cranlogs.r-pkg.org">
+	It is hosted <a href="https://cranlogs.r-pkg.org">
 	  http://cranlogs.r-pkg.org</a> and its API is discussed
 	at the project page:
 	<a href="https://github.com/metacran/cranlogs.app">
@@ -136,8 +136,8 @@
       <h3 id="rversions">R versions</h3>
       <p>
 	Small API that reports current and old R versions. It is
-	hosted at <a href="http://rversions.r-pkg.org">
-	  http://rversions.r-pkg.org</a> and it API is documented
+	hosted at <a href="https://rversions.r-pkg.org">
+	  https://rversions.r-pkg.org</a> and it API is documented
 	at the project page:
 	<a href="https://github.com/metacran/rversions.app">
 	  https://github.com/metacran/rversions.app</a>.


### PR DESCRIPTION
Some urls use http although a https version is available.

Fix #105 

PS: used the github online editor to make the changes. Have not tested it.